### PR TITLE
#10 fix: websocket does not work if the valcons address is used

### DIFF
--- a/td2/provider-default.go
+++ b/td2/provider-default.go
@@ -161,6 +161,16 @@ func (d *DefaultProvider) QueryUnvotedOpenProposalIds(ctx context.Context) ([]ui
 }
 
 func (d *DefaultProvider) QueryValidatorInfo(ctx context.Context) (pub []byte, moniker string, jailed bool, bonded bool, err error) {
+	if strings.Contains(d.ChainConfig.ValAddress, "valcons") {
+		_, bz, err := bech32.DecodeAndConvert(d.ChainConfig.ValAddress)
+		if err != nil {
+			return nil, "", false, false, errors.New("could not decode and convert your address" + d.ChainConfig.ValAddress)
+		}
+
+		hexAddress := fmt.Sprintf("%X", bz)
+		return ToBytes(hexAddress), d.ChainConfig.ValAddress, false, true, nil
+	}
+
 	q := staking.QueryValidatorRequest{
 		ValidatorAddr: d.ChainConfig.ValAddress,
 	}


### PR DESCRIPTION
This used to work in the original repo's `develop` branch. We broke it when did some refactoring in https://github.com/Firstset/tenderduty/commit/f4799c9e024f918be9043f305dc06273f2032d80.