### PR TITLE
Add governance alerts configuration and handling for unvoted proposals

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -116,6 +116,9 @@ chains:
       # Should an alert be sent if no RPC servers are responding? (Note this alarm is instantaneous with no delay)
       alert_if_no_servers: yes
 
+      # Should alerts be sent there are open governance proposals?
+      governance_alerts: yes
+
       # for this *specific* chain it's possible to override alert settings. If the api_key or webhook addresses are empty,
       # the global settings will be used. Note, enabled must be set both globally and for each chain.
 

--- a/td2/alert.go
+++ b/td2/alert.go
@@ -685,18 +685,21 @@ func (cc *ChainConfig) watch() {
 			unvotedProposalMap[id] = true
 		}
 
-		for _, proposalID := range cc.unvotedOpenGovProposalIds {
-			id := fmt.Sprintf(idTemplate, cc.valInfo.Valcons, proposalID)
-			alertMsg := fmt.Sprintf(msgTemplate, proposalID)
+		// Only send governance alerts if they're enabled
+		if cc.Alerts.GovernanceAlerts {
+			for _, proposalID := range cc.unvotedOpenGovProposalIds {
+				id := fmt.Sprintf(idTemplate, cc.valInfo.Valcons, proposalID)
+				alertMsg := fmt.Sprintf(msgTemplate, proposalID)
 
-			// Send alert for this specific proposal
-			td.alert(
-				cc.name,
-				alertMsg,
-				"warning",
-				false,
-				&id,
-			)
+				// Send alert for this specific proposal
+				td.alert(
+					cc.name,
+					alertMsg,
+					"warning",
+					false,
+					&id,
+				)
+			}
 		}
 
 		// check and resolve the alert if the proposal has been voted on

--- a/td2/types.go
+++ b/td2/types.go
@@ -189,6 +189,9 @@ type AlertConfig struct {
 	// AlertIfNoServers: should an alert be sent if no servers are reachable?
 	AlertIfNoServers bool `yaml:"alert_if_no_servers"`
 
+	// Whether to alert on unvoted governance proposals
+	GovernanceAlerts bool `yaml:"governance_alerts"`
+
 	// PagerdutyAlerts: Should pagerduty alerts be sent for this chain? Both 'config.pagerduty.enabled: yes' and this must be set.
 	// Deprecated: use Pagerduty.Enabled instead
 	PagerdutyAlerts bool `yaml:"pagerduty_alerts"`

--- a/td2/validator.go
+++ b/td2/validator.go
@@ -127,25 +127,20 @@ func (cc *ChainConfig) GetValInfo(first bool) (err error) {
 		}
 	}
 
-	if cc.Alerts.GovernanceAlerts {
-		unvotedProposalIds, err := provider.QueryUnvotedOpenProposalIds(ctx)
-		if err == nil {
-			cc.unvotedOpenGovProposalIds = unvotedProposalIds
-			if td.Prom {
-				td.statsChan <- cc.mkUpdate(metricUnvotedProposals, float64(len(cc.unvotedOpenGovProposalIds)), "")
-			}
-		} else {
-			l(err)
+	// Query for unvoted proposals regardless of alert setting
+	unvotedProposalIds, err := provider.QueryUnvotedOpenProposalIds(ctx)
+	if err == nil {
+		cc.unvotedOpenGovProposalIds = unvotedProposalIds
+		if td.Prom {
+			td.statsChan <- cc.mkUpdate(metricUnvotedProposals, float64(len(cc.unvotedOpenGovProposalIds)), "")
 		}
 	} else {
-		// Clear any existing proposals when governance alerts are disabled
-		cc.unvotedOpenGovProposalIds = nil
-		if td.Prom {
-			td.statsChan <- cc.mkUpdate(metricUnvotedProposals, 0, "")
-		}
-		if first {
-			l(fmt.Sprintf("ℹ️ Governance alerts disabled for %s (%s)", cc.ValAddress, cc.valInfo.Moniker))
-		}
+		l(err)
+	}
+
+	// Log if governance alerts are disabled (only on first run)
+	if first && !cc.Alerts.GovernanceAlerts {
+		l(fmt.Sprintf("ℹ️ Governance alerts disabled for %s (%s)", cc.ValAddress, cc.valInfo.Moniker))
 	}
 
 	signingInfo, err := provider.QuerySigningInfo(ctx)


### PR DESCRIPTION
Quick change to allow the ability to disable governance proposal alerts:
• Added `governance_alerts` flag to config.yml (at the Chain level)
• If flag is set to `false`, then gov-props alerts are not created.


Not a go expert, so I'm sure I'm missing something else here.