### PR TITLE
Add chain id to chain name in alerts

### DIFF
--- a/td2/alert.go
+++ b/td2/alert.go
@@ -68,7 +68,6 @@ func (a *alarmCache) clearNoBlocks(cc *ChainConfig) {
 		if strings.HasPrefix(clearAlarm, "stalled: have not seen a new block on") {
 			td.alert(
 				cc.name,
-				cc.ChainId,
 				fmt.Sprintf("stalled: have not seen a new block on %s in %d minutes", cc.ChainId, cc.Alerts.Stalled),
 				"info",
 				true,

--- a/td2/alert.go
+++ b/td2/alert.go
@@ -68,6 +68,7 @@ func (a *alarmCache) clearNoBlocks(cc *ChainConfig) {
 		if strings.HasPrefix(clearAlarm, "stalled: have not seen a new block on") {
 			td.alert(
 				cc.name,
+				cc.ChainId,
 				fmt.Sprintf("stalled: have not seen a new block on %s in %d minutes", cc.ChainId, cc.Alerts.Stalled),
 				"info",
 				true,
@@ -371,7 +372,7 @@ func (c *Config) alert(chainName, message, severity string, resolved bool, id *s
 		slk:          c.Slack.Enabled && c.Chains[chainName].Alerts.Slack.Enabled,
 		severity:     severity,
 		resolved:     resolved,
-		chain:        chainName,
+		chain:        fmt.Sprintf("%s (%s)", chainName, c.Chains[chainName].ChainId),
 		message:      message,
 		uniqueId:     uniq,
 		key:          c.Chains[chainName].Alerts.Pagerduty.ApiKey,
@@ -482,7 +483,7 @@ func (cc *ChainConfig) watch() {
 					false,
 					&cc.valInfo.Valcons,
 				)
-			} else if !cc.lastBlockTime.Before(time.Now().Add(time.Duration(-cc.Alerts.Stalled)*time.Minute)) {
+			} else if !cc.lastBlockTime.Before(time.Now().Add(time.Duration(-cc.Alerts.Stalled) * time.Minute)) {
 				alarms.clearNoBlocks(cc)
 				cc.lastBlockAlarm = false
 				cc.activeAlerts = alarms.getCount(cc.name)


### PR DESCRIPTION
Before:
```
Initia: 💜 Resolved:  - [WARNING] There is an open proposal (#26) that the validator has not voted on
```
After:
```
Initia (interwoven-1): 💜 Resolved:  - [WARNING] There is an open proposal (#26) that the validator has not voted on
```

Why:
In our case, we use the same alert channels for both mainnet and testnet, and for some alerts (i.e. proposal alerts) we need to do an additional check for the chain id.