### PR TITLE
#16 fix false-positive proposal alerts

### DIFF
--- a/td2/provider-default.go
+++ b/td2/provider-default.go
@@ -148,7 +148,7 @@ func (d *DefaultProvider) QueryUnvotedOpenProposalIds(ctx context.Context) ([]ui
 						l(fmt.Sprintf("⚠️ Error checking if validator voted: %v", err))
 					}
 
-					if !hasVoted {
+					if err == nil && !hasVoted {
 						unvotedProposalsIds = append(unvotedProposalsIds, proposal.ProposalId)
 					}
 				}


### PR DESCRIPTION
It is possible that a call to query vote transactions fails with an error such as a timeout. In the current version, this is considered as the validator has not voted on the proposal. This PR changes it to ignore the proposal when there are errors in querying the vote transaction. This is totally fine because Tenderduty regularly checks a validator's state and rpc-endpoint errors are usually transient. By ignoring the errors in querying vote transactions, we avoid false-positive alerts of unvoted proposals.