### PR TITLE
#15 support self-signed certificates for various connections

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -11,6 +11,9 @@ hide_logs: no
 node_down_alert_minutes: 3
 # Node Down alert Pagerduty Severity
 node_down_alert_severity: critical
+# whether skip the verification of TLS certificates, when set to `yes` Tenderduty will skip certificate verification and accept self-signed certs
+# NOTE: this flag should be false in a production environment
+tls_skip_verify: no
 
 # Should the prometheus exporter be enabled?
 prometheus_enabled: yes

--- a/td2/provider-default.go
+++ b/td2/provider-default.go
@@ -2,6 +2,7 @@ package tenderduty
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -55,8 +56,12 @@ func (d *DefaultProvider) CheckIfValidatorVoted(ctx context.Context, proposalID 
 	params.Add("per_page", "1")
 
 	// Create a reusable HTTP client with timeout
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: td.TLSSkipVerify},
+	}
 	client := &http.Client{
-		Timeout: 5 * time.Second, // Add reasonable timeout
+		Transport: tr,
+		Timeout:   5 * time.Second, // Add reasonable timeout
 	}
 
 	// Store the last error to return if all nodes fail

--- a/td2/provider-namada.go
+++ b/td2/provider-namada.go
@@ -3,6 +3,7 @@ package tenderduty
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -92,8 +93,12 @@ func (d *NamadaProvider) QueryUnvotedOpenProposalIds(ctx context.Context) ([]uin
 	validatorAddress, ok2 := d.ChainConfig.Provider.Configs["validator_address"].(string)
 	if ok1 && ok2 {
 		// Create a reusable HTTP client with timeout
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: td.TLSSkipVerify},
+		}
 		httpClient := &http.Client{
-			Timeout: 5 * time.Second, // Add reasonable timeout
+			Transport: tr,
+			Timeout:   5 * time.Second, // Add reasonable timeout
 		}
 
 		urls := make([]string, len(indexers))

--- a/td2/rpc.go
+++ b/td2/rpc.go
@@ -2,6 +2,7 @@ package tenderduty
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -289,7 +290,11 @@ func getStatusWithEndpoint(ctx context.Context, u string) (string, bool, error) 
 		return "", false, err
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: td.TLSSkipVerify},
+	}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", false, err
 	}

--- a/td2/types.go
+++ b/td2/types.go
@@ -52,6 +52,9 @@ type Config struct {
 	// NodeDownSeverity controls the Pagerduty severity when notifying if a node is down.
 	NodeDownSeverity string `yaml:"node_down_alert_severity"`
 
+	// whether skip the TLS verification
+	TLSSkipVerify bool `yaml:"tls_skip_verify"`
+
 	// Prom controls if the prometheus exporter is enabled.
 	Prom bool `yaml:"prometheus_enabled"`
 	// PrometheusListenPort is the port number used by the prometheus web server

--- a/td2/ws.go
+++ b/td2/ws.go
@@ -92,7 +92,7 @@ func (cc *ChainConfig) WsRun() {
 		break
 	}
 
-	cc.wsclient, err = NewClient(cc.client.Remote(), true)
+	cc.wsclient, err = NewClient(cc.client.Remote(), td.TLSSkipVerify)
 	if err != nil {
 		l(err)
 		cancel()

--- a/td2/ws.go
+++ b/td2/ws.go
@@ -2,6 +2,7 @@ package tenderduty
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -447,8 +448,18 @@ func NewClient(u string, allowInsecure bool) (*TmConn, error) {
 	// TODO: add custom UDS dialer
 	case dialUnix:
 
-	// TODO: add custom TLS dialer to allow self-signed certs.
-	// case allowInsecure && endpoint.Scheme == "wss":
+	case allowInsecure && endpoint.Scheme == "wss":
+		// Add custom TLS dialer to allow self-signed certs
+		dialer := &websocket.Dialer{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+			HandshakeTimeout: 10 * time.Second,
+		}
+		conn, _, err = dialer.Dial(endpoint.String(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("could not dial wss client to %s: %s", endpoint.String(), err.Error())
+		}
 
 	default:
 		conn, _, err = websocket.DefaultDialer.Dial(endpoint.String(), nil)


### PR DESCRIPTION
This PR adds a new config flag `tls_skip_verify`. When it is set to `true`, Tenderduty skips the certificate verification and then it can be used for endpoints with self-signed certificates. The flag is set as `false` by default and it should not be enabled in a production environment.