### PR TITLE
#9 resend unvoted proposal alerts after a period of time

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -61,6 +61,10 @@ healthcheck:
   # Rate in which pings are sent in seconds.
   ping_rate: 60
 
+# If governance_alerts for a chain is enabled, the following defines how frequently a reminder should be sent, in hours
+# Optional, the value is 6 (hours) when it is not set, but note that this cannot be configured per chain for now
+governance_alerts_reminder_interval: 6
+
 # The various chains to be monitored. Create a new entry for each chain. The name itself can be arbitrary, but a
 # user-friendly name is recommended.
 chains:

--- a/td2/types.go
+++ b/td2/types.go
@@ -71,6 +71,9 @@ type Config struct {
 	// Healthcheck information
 	Healthcheck HealthcheckConfig `yaml:"healthcheck"`
 
+	// When GovernanceAlerts is true, GovernanceAlertsReminderInterval defines how often to remind the user about unvoted proposals, every 6 hours by default
+	GovernanceAlertsReminderInterval int `yaml:"governance_alerts_reminder_interval"`
+
 	chainsMux sync.RWMutex // prevents concurrent map access for Chains
 	// Chains has settings for each validator to monitor. The map's name does not need to match the chain-id.
 	Chains map[string]*ChainConfig `yaml:"chains"`
@@ -305,6 +308,11 @@ func validateConfig(c *Config) (fatal bool, problems []string) {
 		}
 
 		v.valInfo = &ValInfo{Moniker: "not connected"}
+
+		// when undefined, or invalid, we set 6 as the default value
+		if c.GovernanceAlertsReminderInterval <= 0 {
+			c.GovernanceAlertsReminderInterval = 6
+		}
 
 		// the bools for enabling alerts are deprecated with full configs preferred,
 		// don't break if someone is still using them:


### PR DESCRIPTION
Some governance proposals are just open for a short period of time. This PR enables Tenderduty to send governance alerts again, after a certain period of time. The interval is configurable using `governance_alerts_reminder_interval` in a config yaml file. Note that for now this has to be a top-level global config (unlike `governance_alerts` which is a chain-level option).