### PR TITLE
#22 feat: configure each alert channel's severity threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This is a fork of the original [Tenderduty](https://github.com/blockpane/tenderduty) repository, which is no longer maintained by the author, and we have added the following features:
 
-- **[Governance proposal monitoring.](#goverance-proposal-monitoring)** 
-   - Receive alerts when there are proposals in voting period and the validator has not voted on. The alert is resolved once the validator has voted. 
-   - Unvoted proposals are tracked and reported in the dashboard. 
-   - A Prometheus metric is also added to monitor the number of unvoted proposals.
+- **[Governance proposal monitoring.](#goverance-proposal-monitoring)**
+  - Receive alerts when there are proposals in voting period and the validator has not voted on. The alert is resolved once the validator has voted.
+  - Unvoted proposals are tracked and reported in the dashboard.
+  - A Prometheus metric is also added to monitor the number of unvoted proposals.
 - **[Improved support for Namada.](#support-for-namada)** Proper reporting of otherwise missing information such as the Moniker, uptime data or slashing threshold.
 - **[Pre-built binaries.](#pre-built-binaries)** Releases now include pre-built binaries for Linux and MacOS.
 
@@ -114,6 +114,34 @@ chains:
           - https://namada-indexer.0xcryptovestor.com
 ```
 
+### Per-chain Alert Severity Threshold for Different Channels
+
+Thanks to the option `severity_threshold` in the config yaml, users are able to configure what kinds of alerts are sent to which channels. For example, if users want to receive only critical alerts on Pagerduty, but all alerts on Telegram, the following configuration can be used:
+
+```yaml
+# Global setting for pagerduty
+pagerduty:
+  severity_threshold: critical
+
+# Telegram settings
+telegram:
+  severity_threshold: info
+```
+
+Here is a list of all the alerts on Tenderduty.
+
+| AlertName                | AlertMessage                                                            | Severity                                    |
+| ------------------------ | ----------------------------------------------------------------------- | ------------------------------------------- |
+| ChainStalled             | stalled: have not seen a new block on chainX in Y minutes               | critical                                    |
+| NoRPCEndpoints           | no RPC endpoints are working for chainX                                 | critical                                    |
+| ValidatorInactive        | validator X is tombstoned for chainY                                    | critical                                    |
+| ConsecutiveBlocksMissed  | validator has missed X blocks on chainY                                 | configured via `consecutive_priority`       |
+| PercentageBlocksMissed   | validator has missed > X% of the slashing window's blocks on chainY     | configured via `percentage_priority`        |
+| ConsecutiveEmptyBlocks   | validator has proposed X consecutive empty blocks on chainY             | configured via `consecutive_empty_priority` |
+| PercentageEmptyBlocks    | validator has > X% empty blocks (Y of Z proposed blocks) on chainid ... | configured via `empty_percentage_priority`  |
+| RPCNodeDown              | RPC node X has been down for > Y minutes on chainZ                      | configured via `node_down_alert_severity`   |
+| UnvotedGoveranceProposal | There is an open proposal (#X) that the validator has not voted on      | warning                                     |
+
 ### Pre-built binaries
 
 Releases now include pre-built binaries for Linux and MacOS and ARM64/AMD64, as well as a checksum file for verifying the integrity of the downloaded files.
@@ -132,4 +160,3 @@ wget https://github.com/Firstset/tenderduty/blob/main/example-config.yml
 # create the container, port 8888 is for the dashboard, and 28686 is for the prometheus metrics
 docker run -d --name tenderduty -p "8888:8888" -p "28686:28686" --restart unless-stopped -v $(pwd)/config.yml:/var/lib/tenderduty/config.yml -v $(pwd)/.tenderduty-state.json:/var/lib/tenderduty/.tenderduty-state.json firstset/tenderduty:latest
 ```
-

--- a/example-config.yml
+++ b/example-config.yml
@@ -28,6 +28,9 @@ pagerduty:
   api_key: aaaaaaaaaaaabbbbbbbbbbbbbcccccccccccc
   # Not currently used, but will be soon. This allows setting escalation priorities etc.
   default_severity: alert
+  # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
+  # In Tenderduty there are three severity levels: info, warning, and critical. `severity_threshold: critical` means that Tenderduty only sends critical alerts to this channel (Pagerduty)
+  severity_threshold: critical
 
 # Discord settings
 discord:
@@ -35,6 +38,8 @@ discord:
   enabled: no
   # The webhook is set by right-clicking on a channel, editing the settings, and configuring a webhook in the intergrations section.
   webhook: https://discord.com/api/webhooks/999999999999999999/zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+  # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
+  severity_threshold: info
 
 # Telegram settings
 telegram:
@@ -44,6 +49,8 @@ telegram:
   api_key: "5555555555:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   # The group ID for the chat where messages will be sent. Google how to find this, will include better info later.
   channel: "-666666666"
+  # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
+  severity_threshold: info
 
 # Slack settings
 slack:
@@ -51,6 +58,8 @@ slack:
   enabled: no
   # The webhook can be added in the Slack app directory.
   webhook: https://hooks.slack.com/services/AAAAAAAAAAAAAAAAAAAAAAA/bbbbbbbbbbbbbbbbbbbbbbbb
+  # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
+  severity_threshold: info
 
 # Healthcheck settings (dead man's switch)
 healthcheck:


### PR DESCRIPTION
Tenderduty only sends alerts to this channel when the alert severity is equal to or above the channel's alert severity threshold. Here is the list of all the alerts and their severities:

| AlertName                | AlertMessage                                                            | Severity                                    |
| ------------------------ | ----------------------------------------------------------------------- | ------------------------------------------- |
| ChainStalled             | stalled: have not seen a new block on chainX in Y minutes               | critical                                    |
| NoRPCEndpoints           | no RPC endpoints are working for chainX                                 | critical                                    |
| ValidatorInactive        | validator X is tombstoned for chainY                                    | critical                                    |
| ConsecutiveBlocksMissed  | validator has missed X blocks on chainY                                 | configured via `consecutive_priority`       |
| PercentageBlocksMissed   | validator has missed > X% of the slashing window's blocks on chainY     | configured via `percentage_priority`        |
| ConsecutiveEmptyBlocks   | validator has proposed X consecutive empty blocks on chainY             | configured via `consecutive_empty_priority` |
| PercentageEmptyBlocks    | validator has > X% empty blocks (Y of Z proposed blocks) on chainid ... | configured via `empty_percentage_priority`  |
| RPCNodeDown              | RPC node X has been down for > Y minutes on chainZ                      | configured via `node_down_alert_severity`   |
| UnvotedGoveranceProposal | There is an open proposal (#X) that the validator has not voted on      | warning                                     |

The default severity threshold for each channel:

- Pagerduty: `critical`
- Telegram, Discord, and Slack: `info`