### PR TITLE
Support default alert config

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,5 +1,5 @@
 ---
-name: Gosec
+name: Gosec Security Scanner
 on:
   push:
     branches:
@@ -12,7 +12,7 @@ on:
       - release/*
       - develop
 jobs:
-  tests:
+  scan:
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,73 @@
+---
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+      - develop
+  pull_request:
+    branches:
+      - main
+      - release/*
+      - develop
+
+env:
+  GO_VERSION: "1.18"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Run unit tests
+        run: go test -v -race -coverprofile=coverage.out ./...
+
+      - name: Generate coverage report
+        run: go tool cover -html=coverage.out -o coverage.html
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: |
+            coverage.out
+            coverage.html
+          retention-days: 30
+
+      - name: Check test coverage
+        run: |
+          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
+          echo "Total test coverage: ${COVERAGE}%"
+          if (( $(echo "${COVERAGE} < 50.0" | bc -l) )); then
+            echo "::warning::Test coverage is below 50% (${COVERAGE}%)"
+          fi
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,3 @@
----
 name: Unit Tests
 
 on:
@@ -14,7 +13,7 @@ on:
       - develop
 
 env:
-  GO_VERSION: "1.18"
+  GO_VERSION: "1.24"
 
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 build:
 	CGO_CFLAGS="-Wno-deprecated-declarations" go build -ldflags '-s -w' -trimpath -o ./tenderduty main.go
+
+test:
+	CGO_CFLAGS="-Wno-deprecated-declarations" go test -v ./...

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a fork of the original [Tenderduty](https://github.com/blockpane/tenderd
    - Voting power is now reported in the dashboard, and alerts are fired upon changes above a configurable threshold.
    - Staking APR is now reported in the dashboard.
 - **[Configurable severity threshold per channel.](#channel-severity-thresholds)** Configure different minimum notification levels for each channel (e.g. "critical" for Pagerduty, "info" and above for Telegram).
+- **Global default alert configuration.** Define alert settings once in `default_alert_config` and override them per chain when needed.
 - **[Improved support for Namada.](#support-for-namada)** Proper reporting of otherwise missing information such as the Moniker, uptime data or slashing threshold.
 - **[Pre-built binaries.](#pre-built-binaries)** Releases now include pre-built binaries for Linux and MacOS.
 - **[Design improvements.](#design-improvements)** Restyled dashboard design.

--- a/example-config.yml
+++ b/example-config.yml
@@ -28,7 +28,6 @@ convert_to_fiat:
   currency: USD # or EUR, SEK, etc.
   cache_expiration: 8 # cache the pricing data for 8 hours
 
-
 # Default alert configuration used for all chains unless overridden
 default_alert_config:
   pagerduty:
@@ -67,29 +66,61 @@ default_alert_config:
     webhook: https://hooks.slack.com/services/AAAAAAAAAAAAAAAAAAAAAAA/bbbbbbbbbbbbbbbbbbbbbbbb
     # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
     severity_threshold: info
+
   # Alert defaults shared by all chains
+  # If the chain stops seeing new blocks, should an alert be sent?
   stalled_enabled: yes
+  # How long a halted chain takes in minutes to generate an alarm
   stalled_minutes: 10
+  # Most basic alarm, you just missed x blocks ... would you like to know?
   consecutive_enabled: yes
+  # How many missed blocks should trigger a notification?
   consecutive_missed: 5
+  # Consecutive Missed alert Pagerduty Severity
   consecutive_priority: critical
+
+  # For each chain there is a specific window of blocks and a percentage of missed blocks that will result in
+  # a downtime jail infraction. Should an alert be sent if a certain percentage of this window is exceeded?
   percentage_enabled: no
+  # What percentage should trigger the alert
   percentage_missed: 10
+  # Percentage Missed alert Pagerduty Severity
   percentage_priority: warning
-  consecutive_empty_enabled: yes
-  consecutive_empty: 3
-  consecutive_empty_priority: critical
-  empty_percentage_enabled: yes
+
+  # Empty blocks notification configuration
+  consecutive_empty_enabled: no
+  # How many consecutive empty blocks should trigger a notification?
+  consecutive_empty: 5
+  # Consecutive Empty alert Pagerduty Severity
+  consecutive_empty_priority: warning
+
+  # For some Cosmos EVM chains, empty consensus blocks may decrease execution uptime
+  # since they aren't included in EVM state. Should an alert be sent if empty blocks are detected?
+  empty_percentage_enabled: no
+  # What percentage should trigger the alert
   empty_percentage: 2
+  # Percentage Empty alert Pagerduty Severity
   empty_percentage_priority: warning
+
+  # Should an alert be sent if the validator is not in the active set ie, jailed,
+  # tombstoned, unbonding?
   alert_if_inactive: yes
+  # Should an alert be sent if no RPC servers are responding? (Note this alarm is instantaneous with no delay)
+
   alert_if_no_servers: yes
+  # Should alerts be sent there are open governance proposals?
   governance_alerts: yes
+
+  # Alert when a validator's stake change goes beyond the threshold
   stake_change_alerts: yes
-  stake_change_drop_threshold: 0.1
-  stake_change_increase_threshold: 0.1
+  stake_change_drop_threshold: 0.05 # meaning 5%
+  stake_change_increase_threshold: 0.05 # meaning 5%
+
+  # Alert when a validator has more than the threhold value of unclaimed rewards
+  # The threshold is defined with a fiat currency unit like USD, so this feature requires properly configuring coin_market_cap_api_token and enabling convert_to_fiat
   unclaimed_rewards_alerts: yes
   unclaimed_rewards_threshold_in_fiat_currency: 10000
+
 # Healthcheck settings (dead man's switch)
 healthcheck:
   # Send pings to determine if the monitor is running?
@@ -124,85 +155,15 @@ chains:
     # If the inflation rate cannot be queried, you can use this option to explicitly set the value
     inflationRate: 0.04
 
-    # Controls various alert settings for each chain.
+    # the following section follows the same structure defined in `default_alert_config` and is used for overriding specific values
     alerts:
-      # If the chain stops seeing new blocks, should an alert be sent?
-      stalled_enabled: yes
-      # How long a halted chain takes in minutes to generate an alarm
-      stalled_minutes: 10
-
-      # Most basic alarm, you just missed x blocks ... would you like to know?
-      consecutive_enabled: yes
-      # How many missed blocks should trigger a notification?
-      consecutive_missed: 5
-      # Consecutive Missed alert Pagerduty Severity
-      consecutive_priority: critical
-
-      # For each chain there is a specific window of blocks and a percentage of missed blocks that will result in
-      # a downtime jail infraction. Should an alert be sent if a certain percentage of this window is exceeded?
-      percentage_enabled: no
-      # What percentage should trigger the alert
-      percentage_missed: 10
-      # Percentage Missed alert Pagerduty Severity
-      percentage_priority: warning
-
-      # Empty blocks notification configuration
+      # an example for enabling empty blocks alert, which is disabled by default
       consecutive_empty_enabled: yes
-      # How many consecutive empty blocks should trigger a notification?
       consecutive_empty: 3
-      # Consecutive Empty alert Pagerduty Severity
       consecutive_empty_priority: critical
-
-      # For some Cosmos EVM chains, empty consensus blocks may decrease execution uptime
-      # since they aren't included in EVM state. Should an alert be sent if empty blocks are detected?
-      empty_percentage_enabled: yes
-      # What percentage should trigger the alert
-      empty_percentage: 2
-      # Percentage Empty alert Pagerduty Severity
-      empty_percentage_priority: warning
-
-      # Should an alert be sent if the validator is not in the active set ie, jailed,
-      # tombstoned, unbonding?
-      alert_if_inactive: yes
-      # Should an alert be sent if no RPC servers are responding? (Note this alarm is instantaneous with no delay)
-      alert_if_no_servers: yes
-
-      # Should alerts be sent there are open governance proposals?
-      governance_alerts: yes
-
-      # Alert when a validator's stake change goes beyond the threshold
-      stake_change_alerts: yes
-      stake_change_drop_threshold: 0.1 # meaning 10%
-      stake_change_increase_threshold: 0.1 # meaning 10%
-
-      # Alert when a validator has more than the threhold value of unclaimed rewards
-      # The threshold is defined with a fiat currency unit like USD, so this feature requires properly configuring coin_market_cap_api_token and enabling convert_to_fiat
-      unclaimed_rewards_alerts: yes
-      unclaimed_rewards_threshold_in_fiat_currency: 10000
-
-      # for this *specific* chain it's possible to override alert settings. If the api_key or webhook addresses are empty,
-      # the global settings will be used. Note, enabled must be set both globally and for each chain.
-
-      # Chain specific setting for pagerduty
+      # an example for disabling the pagerduty alert channel, which is enabled by default
       pagerduty:
-        enabled: yes
-        api_key: "" # uses default if blank
-
-      # Discord settings
-      discord:
-        enabled: yes
-        webhook: "" # uses default if blank
-
-      # Telegram settings
-      telegram:
-        enabled: yes
-        api_key: "" # uses default if blank
-        channel: "" # uses default if blank
-
-      # Slack settings
-      slack:
-        enabled: yes
-        webhook: "" # uses default if blank
+        enabled: no
 
     # This section covers our RPC providers. No LCD (aka REST) endpoints are used, only TM's RPC endpoints
     # Multiple hosts are encouraged, and will be tried sequentially until a working endpoint is discovered.

--- a/example-config.yml
+++ b/example-config.yml
@@ -28,47 +28,68 @@ convert_to_fiat:
   currency: USD # or EUR, SEK, etc.
   cache_expiration: 8 # cache the pricing data for 8 hours
 
-# Global setting for pagerduty
-pagerduty:
-  # Should we use PD? Be aware that if this is set to no it overrides individual chain alerting settings.
-  enabled: no
-  # This is an API key, not oauth token, more details to follow, but check the v1 docs for more info
-  api_key: aaaaaaaaaaaabbbbbbbbbbbbbcccccccccccc
-  # Not currently used, but will be soon. This allows setting escalation priorities etc.
-  default_severity: alert
-  # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
-  # In Tenderduty there are three severity levels: info, warning, and critical. `severity_threshold: critical` means that Tenderduty only sends critical alerts to this channel (Pagerduty)
-  severity_threshold: critical
 
-# Discord settings
-discord:
-  # Alert to discord?
-  enabled: no
-  # The webhook is set by right-clicking on a channel, editing the settings, and configuring a webhook in the intergrations section.
-  webhook: https://discord.com/api/webhooks/999999999999999999/zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
-  # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
-  severity_threshold: info
+# Default alert configuration used for all chains unless overridden
+default_alert_config:
+  pagerduty:
+    # Should we use PD? Be aware that if this is set to no it overrides individual chain alerting settings.
+    enabled: no
+    # This is an API key, not oauth token, more details to follow, but check the v1 docs for more info
+    api_key: aaaaaaaaaaaabbbbbbbbbbbbbcccccccccccc
+    # Not currently used, but will be soon. This allows setting escalation priorities etc.
+    default_severity: alert
+    # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
+    # In Tenderduty there are three severity levels: info, warning, and critical. `severity_threshold: critical` means that Tenderduty only sends critical alerts to this channel (Pagerduty)
+    severity_threshold: critical
 
-# Telegram settings
-telegram:
-  # Alert via telegram? Note: also supersedes chain-specific settings
-  enabled: no
-  # API key ... talk to @BotFather
-  api_key: "5555555555:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-  # The group ID for the chat where messages will be sent. Google how to find this, will include better info later.
-  channel: "-666666666"
-  # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
-  severity_threshold: info
+  discord:
+    # Alert to discord?
+    enabled: no
+    # The webhook is set by right-clicking on a channel, editing the settings, and configuring a webhook in the intergrations section.
+    webhook: https://discord.com/api/webhooks/999999999999999999/zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+    # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
+    severity_threshold: info
 
-# Slack settings
-slack:
-  # Send alerts to Slack?
-  enabled: no
-  # The webhook can be added in the Slack app directory.
-  webhook: https://hooks.slack.com/services/AAAAAAAAAAAAAAAAAAAAAAA/bbbbbbbbbbbbbbbbbbbbbbbb
-  # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
-  severity_threshold: info
+  telegram:
+    # Alert via telegram? Note: also supersedes chain-specific settings
+    enabled: no
+    # API key ... talk to @BotFather
+    api_key: "5555555555:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    # The group ID for the chat where messages will be sent. Google how to find this, will include better info later.
+    channel: "-666666666"
+    # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
+    severity_threshold: info
 
+  slack:
+    # Send alerts to Slack?
+    enabled: no
+    # The webhook can be added in the Slack app directory.
+    webhook: https://hooks.slack.com/services/AAAAAAAAAAAAAAAAAAAAAAA/bbbbbbbbbbbbbbbbbbbbbbbb
+    # Severity threshold defines the minimum severity level at which the alerts are sent to this channel
+    severity_threshold: info
+  # Alert defaults shared by all chains
+  stalled_enabled: yes
+  stalled_minutes: 10
+  consecutive_enabled: yes
+  consecutive_missed: 5
+  consecutive_priority: critical
+  percentage_enabled: no
+  percentage_missed: 10
+  percentage_priority: warning
+  consecutive_empty_enabled: yes
+  consecutive_empty: 3
+  consecutive_empty_priority: critical
+  empty_percentage_enabled: yes
+  empty_percentage: 2
+  empty_percentage_priority: warning
+  alert_if_inactive: yes
+  alert_if_no_servers: yes
+  governance_alerts: yes
+  stake_change_alerts: yes
+  stake_change_drop_threshold: 0.1
+  stake_change_increase_threshold: 0.1
+  unclaimed_rewards_alerts: yes
+  unclaimed_rewards_threshold_in_fiat_currency: 10000
 # Healthcheck settings (dead man's switch)
 healthcheck:
   # Send pings to determine if the monitor is running?

--- a/td2/alert.go
+++ b/td2/alert.go
@@ -388,10 +388,10 @@ func (c *Config) alert(chainName, message, severity string, resolved bool, id *s
 	}
 	c.chainsMux.RLock()
 	a := &alertMsg{
-		pd:           c.Pagerduty.Enabled && c.Chains[chainName].Alerts.Pagerduty.Enabled,
-		disc:         c.Discord.Enabled && c.Chains[chainName].Alerts.Discord.Enabled,
-		tg:           c.Telegram.Enabled && c.Chains[chainName].Alerts.Telegram.Enabled,
-		slk:          c.Slack.Enabled && c.Chains[chainName].Alerts.Slack.Enabled,
+		pd:           c.DefaultAlertConfig.Pagerduty.Enabled && c.Chains[chainName].Alerts.Pagerduty.Enabled,
+		disc:         c.DefaultAlertConfig.Discord.Enabled && c.Chains[chainName].Alerts.Discord.Enabled,
+		tg:           c.DefaultAlertConfig.Telegram.Enabled && c.Chains[chainName].Alerts.Telegram.Enabled,
+		slk:          c.DefaultAlertConfig.Slack.Enabled && c.Chains[chainName].Alerts.Slack.Enabled,
 		severity:     severity,
 		resolved:     resolved,
 		chain:        fmt.Sprintf("%s (%s)", chainName, c.Chains[chainName].ChainId),

--- a/td2/alert.go
+++ b/td2/alert.go
@@ -426,10 +426,6 @@ func (c *Config) alert(chainName, message, severity string, resolved bool, id *s
 // and also updates a few prometheus stats
 // FIXME: not watching for nodes that are lagging the head block!
 func (cc *ChainConfig) watch() {
-	// print `cc` as a json string here, useful for debugging
-	jsonBytes, _ := json.MarshalIndent(td, "", "  ")
-	l("Tenderduty config:", string(jsonBytes))
-
 	var missedAlarm, pctAlarm, noNodes, emptyBlocksAlarm, emptyPctAlarm, stakeChangeAlarm, unclaimedRewardsAlarm bool
 	inactive := "jailed"
 	nodeAlarms := make(map[string]bool)

--- a/td2/alert.go
+++ b/td2/alert.go
@@ -73,7 +73,7 @@ func (a *alarmCache) clearNoBlocks(cc *ChainConfig) {
 		if strings.HasPrefix(clearAlarm, "stalled: have not seen a new block on") {
 			td.alert(
 				cc.name,
-				fmt.Sprintf("stalled: have not seen a new block on %s in %d minutes", cc.ChainId, cc.Alerts.Stalled),
+				fmt.Sprintf("stalled: have not seen a new block on %s in %d minutes", cc.ChainId, intVal(cc.Alerts.Stalled)),
 				"critical",
 				true,
 				&cc.valInfo.Valcons,
@@ -388,10 +388,10 @@ func (c *Config) alert(chainName, message, severity string, resolved bool, id *s
 	}
 	c.chainsMux.RLock()
 	a := &alertMsg{
-		pd:           c.DefaultAlertConfig.Pagerduty.Enabled && c.Chains[chainName].Alerts.Pagerduty.Enabled,
-		disc:         c.DefaultAlertConfig.Discord.Enabled && c.Chains[chainName].Alerts.Discord.Enabled,
-		tg:           c.DefaultAlertConfig.Telegram.Enabled && c.Chains[chainName].Alerts.Telegram.Enabled,
-		slk:          c.DefaultAlertConfig.Slack.Enabled && c.Chains[chainName].Alerts.Slack.Enabled,
+		pd:           boolVal(c.DefaultAlertConfig.Pagerduty.Enabled) && boolVal(c.Chains[chainName].Alerts.Pagerduty.Enabled),
+		disc:         boolVal(c.DefaultAlertConfig.Discord.Enabled) && boolVal(c.Chains[chainName].Alerts.Discord.Enabled),
+		tg:           boolVal(c.DefaultAlertConfig.Telegram.Enabled) && boolVal(c.Chains[chainName].Alerts.Telegram.Enabled),
+		slk:          boolVal(c.DefaultAlertConfig.Slack.Enabled) && boolVal(c.Chains[chainName].Alerts.Slack.Enabled),
 		severity:     severity,
 		resolved:     resolved,
 		chain:        fmt.Sprintf("%s (%s)", chainName, c.Chains[chainName].ChainId),
@@ -426,6 +426,10 @@ func (c *Config) alert(chainName, message, severity string, resolved bool, id *s
 // and also updates a few prometheus stats
 // FIXME: not watching for nodes that are lagging the head block!
 func (cc *ChainConfig) watch() {
+	// print `cc` as a json string here, useful for debugging
+	jsonBytes, _ := json.MarshalIndent(td, "", "  ")
+	l("Tenderduty config:", string(jsonBytes))
+
 	var missedAlarm, pctAlarm, noNodes, emptyBlocksAlarm, emptyPctAlarm, stakeChangeAlarm, unclaimedRewardsAlarm bool
 	inactive := "jailed"
 	nodeAlarms := make(map[string]bool)
@@ -435,7 +439,7 @@ func (cc *ChainConfig) watch() {
 	for {
 		if cc.valInfo == nil || cc.valInfo.Moniker == "not connected" {
 			time.Sleep(time.Second)
-			if cc.Alerts.AlertIfNoServers && !noNodes && cc.noNodes && noNodesSec >= 60*td.NodeDownMin {
+			if boolVal(cc.Alerts.AlertIfNoServers) && !noNodes && cc.noNodes && noNodesSec >= 60*td.NodeDownMin {
 				noNodes = true
 				td.alert(
 					cc.name,
@@ -463,7 +467,7 @@ func (cc *ChainConfig) watch() {
 
 		// alert if we can't monitor
 		switch {
-		case cc.Alerts.AlertIfNoServers && !noNodes && cc.noNodes:
+		case boolVal(cc.Alerts.AlertIfNoServers) && !noNodes && cc.noNodes:
 			noNodesSec += 2
 			if noNodesSec <= 30*td.NodeDownMin {
 				if noNodesSec%20 == 0 {
@@ -481,7 +485,7 @@ func (cc *ChainConfig) watch() {
 					&cc.valInfo.Valcons,
 				)
 			}
-		case cc.Alerts.AlertIfNoServers && noNodes && !cc.noNodes:
+		case boolVal(cc.Alerts.AlertIfNoServers) && noNodes && !cc.noNodes:
 			noNodes = false
 			td.alert(
 				cc.name,
@@ -495,18 +499,18 @@ func (cc *ChainConfig) watch() {
 		}
 
 		// stalled chain detection
-		if cc.Alerts.StalledAlerts && !cc.lastBlockTime.IsZero() {
-			if !cc.lastBlockAlarm && cc.lastBlockTime.Before(time.Now().Add(time.Duration(-cc.Alerts.Stalled)*time.Minute)) {
+		if boolVal(cc.Alerts.StalledAlerts) && !cc.lastBlockTime.IsZero() {
+			if !cc.lastBlockAlarm && cc.lastBlockTime.Before(time.Now().Add(time.Duration(-intVal(cc.Alerts.Stalled))*time.Minute)) {
 				// chain is stalled send an alert!
 				cc.lastBlockAlarm = true
 				td.alert(
 					cc.name,
-					fmt.Sprintf("stalled: have not seen a new block on %s in %d minutes", cc.ChainId, cc.Alerts.Stalled),
+					fmt.Sprintf("stalled: have not seen a new block on %s in %d minutes", cc.ChainId, intVal(cc.Alerts.Stalled)),
 					"critical",
 					false,
 					&cc.valInfo.Valcons,
 				)
-			} else if !cc.lastBlockTime.Before(time.Now().Add(time.Duration(-cc.Alerts.Stalled) * time.Minute)) {
+			} else if !cc.lastBlockTime.Before(time.Now().Add(time.Duration(-intVal(cc.Alerts.Stalled)) * time.Minute)) {
 				alarms.clearNoBlocks(cc)
 				cc.lastBlockAlarm = false
 				cc.activeAlerts = alarms.getCount(cc.name)
@@ -514,7 +518,7 @@ func (cc *ChainConfig) watch() {
 		}
 
 		// jailed detection - only alert if it changes.
-		if cc.Alerts.AlertIfInactive && cc.lastValInfo != nil && cc.lastValInfo.Bonded != cc.valInfo.Bonded &&
+		if boolVal(cc.Alerts.AlertIfInactive) && cc.lastValInfo != nil && cc.lastValInfo.Bonded != cc.valInfo.Bonded &&
 			cc.lastValInfo.Moniker == cc.valInfo.Moniker {
 
 			id := cc.valInfo.Valcons + "jailed"
@@ -543,25 +547,25 @@ func (cc *ChainConfig) watch() {
 		}
 
 		// consecutive missed block alarms:
-		if !missedAlarm && cc.Alerts.ConsecutiveAlerts && int(cc.statConsecutiveMiss) >= cc.Alerts.ConsecutiveMissed {
+		if !missedAlarm && boolVal(cc.Alerts.ConsecutiveAlerts) && int(cc.statConsecutiveMiss) >= intVal(cc.Alerts.ConsecutiveMissed) {
 			// alert on missed block counter!
 			missedAlarm = true
 			id := cc.valInfo.Valcons + "consecutive"
 			td.alert(
 				cc.name,
-				fmt.Sprintf("%s has missed %d blocks on %s", cc.valInfo.Moniker, cc.Alerts.ConsecutiveMissed, cc.ChainId),
+				fmt.Sprintf("%s has missed %d blocks on %s", cc.valInfo.Moniker, intVal(cc.Alerts.ConsecutiveMissed), cc.ChainId),
 				cc.Alerts.ConsecutivePriority,
 				false,
 				&id,
 			)
 			cc.activeAlerts = alarms.getCount(cc.name)
-		} else if missedAlarm && int(cc.statConsecutiveMiss) < cc.Alerts.ConsecutiveMissed {
+		} else if missedAlarm && int(cc.statConsecutiveMiss) < intVal(cc.Alerts.ConsecutiveMissed) {
 			// clear the alert
 			missedAlarm = false
 			id := cc.valInfo.Valcons + "consecutive"
 			td.alert(
 				cc.name,
-				fmt.Sprintf("%s has missed %d blocks on %s", cc.valInfo.Moniker, cc.Alerts.ConsecutiveMissed, cc.ChainId),
+				fmt.Sprintf("%s has missed %d blocks on %s", cc.valInfo.Moniker, intVal(cc.Alerts.ConsecutiveMissed), cc.ChainId),
 				cc.Alerts.ConsecutivePriority,
 				true,
 				&id,
@@ -570,25 +574,25 @@ func (cc *ChainConfig) watch() {
 		}
 
 		// window percentage missed block alarms
-		if cc.Alerts.PercentageAlerts && !pctAlarm && 100*float64(cc.valInfo.Missed)/float64(cc.valInfo.Window) > float64(cc.Alerts.Window) {
+		if boolVal(cc.Alerts.PercentageAlerts) && !pctAlarm && 100*float64(cc.valInfo.Missed)/float64(cc.valInfo.Window) > float64(intVal(cc.Alerts.Window)) {
 			// alert on missed block counter!
 			pctAlarm = true
 			id := cc.valInfo.Valcons + "percent"
 			td.alert(
 				cc.name,
-				fmt.Sprintf("%s has missed > %d%% of the slashing window's blocks on %s", cc.valInfo.Moniker, cc.Alerts.Window, cc.ChainId),
+				fmt.Sprintf("%s has missed > %d%% of the slashing window's blocks on %s", cc.valInfo.Moniker, intVal(cc.Alerts.Window), cc.ChainId),
 				cc.Alerts.PercentagePriority,
 				false,
 				&id,
 			)
 			cc.activeAlerts = alarms.getCount(cc.name)
-		} else if cc.Alerts.PercentageAlerts && pctAlarm && 100*float64(cc.valInfo.Missed)/float64(cc.valInfo.Window) < float64(cc.Alerts.Window) {
+		} else if boolVal(cc.Alerts.PercentageAlerts) && pctAlarm && 100*float64(cc.valInfo.Missed)/float64(cc.valInfo.Window) < float64(intVal(cc.Alerts.Window)) {
 			// clear the alert
 			pctAlarm = false
 			id := cc.valInfo.Valcons + "percent"
 			td.alert(
 				cc.name,
-				fmt.Sprintf("%s has missed > %d%% of the slashing window's blocks on %s", cc.valInfo.Moniker, cc.Alerts.Window, cc.ChainId),
+				fmt.Sprintf("%s has missed > %d%% of the slashing window's blocks on %s", cc.valInfo.Moniker, intVal(cc.Alerts.Window), cc.ChainId),
 				cc.Alerts.PercentagePriority,
 				true,
 				&id,
@@ -597,25 +601,25 @@ func (cc *ChainConfig) watch() {
 		}
 
 		// empty blocks alarm handling
-		if !emptyBlocksAlarm && cc.Alerts.ConsecutiveEmptyAlerts && int(cc.statConsecutiveEmpty) >= cc.Alerts.ConsecutiveEmpty {
+		if !emptyBlocksAlarm && boolVal(cc.Alerts.ConsecutiveEmptyAlerts) && int(cc.statConsecutiveEmpty) >= intVal(cc.Alerts.ConsecutiveEmpty) {
 			// alert on empty blocks counter!
 			emptyBlocksAlarm = true
 			id := cc.valInfo.Valcons + "empty"
 			td.alert(
 				cc.name,
-				fmt.Sprintf("%s has proposed %d consecutive empty blocks on %s", cc.valInfo.Moniker, cc.Alerts.ConsecutiveEmpty, cc.ChainId),
+				fmt.Sprintf("%s has proposed %d consecutive empty blocks on %s", cc.valInfo.Moniker, intVal(cc.Alerts.ConsecutiveEmpty), cc.ChainId),
 				cc.Alerts.ConsecutiveEmptyPriority,
 				false,
 				&id,
 			)
 			cc.activeAlerts = alarms.getCount(cc.name)
-		} else if emptyBlocksAlarm && int(cc.statConsecutiveEmpty) < cc.Alerts.ConsecutiveEmpty {
+		} else if emptyBlocksAlarm && int(cc.statConsecutiveEmpty) < intVal(cc.Alerts.ConsecutiveEmpty) {
 			// clear the alert
 			emptyBlocksAlarm = false
 			id := cc.valInfo.Valcons + "empty"
 			td.alert(
 				cc.name,
-				fmt.Sprintf("%s has proposed %d consecutive empty blocks on %s", cc.valInfo.Moniker, cc.Alerts.ConsecutiveEmpty, cc.ChainId),
+				fmt.Sprintf("%s has proposed %d consecutive empty blocks on %s", cc.valInfo.Moniker, intVal(cc.Alerts.ConsecutiveEmpty), cc.ChainId),
 				cc.Alerts.ConsecutiveEmptyPriority,
 				true,
 				&id,
@@ -629,7 +633,7 @@ func (cc *ChainConfig) watch() {
 			emptyBlocksPercent = 100 * float64(cc.statTotalPropsEmpty) / float64(cc.statTotalProps)
 		}
 
-		if cc.Alerts.EmptyPercentageAlerts && !emptyPctAlarm && emptyBlocksPercent > float64(cc.Alerts.EmptyWindow) {
+		if boolVal(cc.Alerts.EmptyPercentageAlerts) && !emptyPctAlarm && emptyBlocksPercent > float64(intVal(cc.Alerts.EmptyWindow)) {
 			// alert on empty block percentage!
 			emptyPctAlarm = true
 			id := cc.valInfo.Valcons + "empty_percent"
@@ -637,7 +641,7 @@ func (cc *ChainConfig) watch() {
 				cc.name,
 				fmt.Sprintf("%s has > %d%% empty blocks (%d of %d proposed blocks) on %s",
 					cc.valInfo.Moniker,
-					cc.Alerts.EmptyWindow,
+					intVal(cc.Alerts.EmptyWindow),
 					int(cc.statTotalPropsEmpty),
 					int(cc.statTotalProps),
 					cc.ChainId),
@@ -646,7 +650,7 @@ func (cc *ChainConfig) watch() {
 				&id,
 			)
 			cc.activeAlerts = alarms.getCount(cc.name)
-		} else if cc.Alerts.EmptyPercentageAlerts && emptyPctAlarm && emptyBlocksPercent < float64(cc.Alerts.EmptyWindow) {
+		} else if boolVal(cc.Alerts.EmptyPercentageAlerts) && emptyPctAlarm && emptyBlocksPercent < float64(intVal(cc.Alerts.EmptyWindow)) {
 			// clear the alert
 			emptyPctAlarm = false
 			id := cc.valInfo.Valcons + "empty_percent"
@@ -654,7 +658,7 @@ func (cc *ChainConfig) watch() {
 				cc.name,
 				fmt.Sprintf("%s has > %d%% empty blocks (%d of %d proposed blocks) on %s",
 					cc.valInfo.Moniker,
-					cc.Alerts.EmptyWindow,
+					intVal(cc.Alerts.EmptyWindow),
 					int(cc.statTotalPropsEmpty),
 					int(cc.statTotalProps),
 					cc.ChainId),
@@ -700,13 +704,13 @@ func (cc *ChainConfig) watch() {
 		}
 
 		// validator stake change alerts
-		if cc.Alerts.StakeChangeAlerts && cc.valInfo != nil && cc.lastValInfo != nil {
+		if boolVal(cc.Alerts.StakeChangeAlerts) && cc.valInfo != nil && cc.lastValInfo != nil {
 			stakeChangePercent := (cc.valInfo.DelegatedTokens - cc.lastValInfo.DelegatedTokens) / cc.lastValInfo.DelegatedTokens
 			trend := "increased"
-			threshold := cc.Alerts.StakeChangeIncreaseThreshold
+			threshold := floatVal(cc.Alerts.StakeChangeIncreaseThreshold)
 			if stakeChangePercent < 0 {
 				trend = "dropped"
-				threshold = cc.Alerts.StakeChangeDropThreshold
+				threshold = floatVal(cc.Alerts.StakeChangeDropThreshold)
 			}
 			id := cc.valInfo.Valcons + "_stake_change"
 			severity := "warning"
@@ -724,7 +728,7 @@ func (cc *ChainConfig) watch() {
 		}
 
 		// validator unclaimed rewards alert
-		if cc.Alerts.UnclaimedRewardsAlerts && td.PriceConversion.Enabled && cc.valInfo.SelfDelegationRewards != nil && cc.valInfo.Commission != nil {
+		if boolVal(cc.Alerts.UnclaimedRewardsAlerts) && td.PriceConversion.Enabled && cc.valInfo.SelfDelegationRewards != nil && cc.valInfo.Commission != nil {
 			totalRewards := github_com_cosmos_cosmos_sdk_types.DecCoin{
 				Denom:  (*cc.valInfo.SelfDelegationRewards)[0].Denom,
 				Amount: github_com_cosmos_cosmos_sdk_types.ZeroDec(),
@@ -736,8 +740,8 @@ func (cc *ChainConfig) watch() {
 				totalRewardsConverted := totalRewards.Amount.MustFloat64() * coinPrice.Price
 				id := cc.valInfo.Valcons + "_unclaimed_rewards"
 				severity := "warning"
-				message := fmt.Sprintf("%s has more than %.0f %s unclaimed rewards on %s", cc.valInfo.Moniker, cc.Alerts.UnclaimedRewardsThreshold, td.PriceConversion.Currency, cc.name)
-				if totalRewardsConverted > cc.Alerts.UnclaimedRewardsThreshold {
+				message := fmt.Sprintf("%s has more than %.0f %s unclaimed rewards on %s", cc.valInfo.Moniker, floatVal(cc.Alerts.UnclaimedRewardsThreshold), td.PriceConversion.Currency, cc.name)
+				if totalRewardsConverted > floatVal(cc.Alerts.UnclaimedRewardsThreshold) {
 					td.alert(cc.name, message, severity, false, &id)
 					unclaimedRewardsAlarm = true
 				} else {
@@ -761,7 +765,7 @@ func (cc *ChainConfig) watch() {
 		}
 
 		// Only send governance alerts if they're enabled
-		if cc.Alerts.GovernanceAlerts {
+		if boolVal(cc.Alerts.GovernanceAlerts) {
 			for _, proposal := range cc.unvotedOpenGovProposals {
 				id := fmt.Sprintf(idTemplate, cc.valInfo.Valcons, proposal.ProposalId)
 				deadline := fmt.Sprintf(", deadline: %s UTC", proposal.VotingEndTime.Format("2006-01-02 15:04"))

--- a/td2/types_test.go
+++ b/td2/types_test.go
@@ -1,0 +1,501 @@
+package tenderduty
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// alertConfigsEqual compares two AlertConfig structs, handling pointer comparisons properly
+func alertConfigsEqual(a, b AlertConfig) bool {
+	return intPtrEqual(a.Stalled, b.Stalled) &&
+		boolPtrEqual(a.StalledAlerts, b.StalledAlerts) &&
+		intPtrEqual(a.ConsecutiveMissed, b.ConsecutiveMissed) &&
+		a.ConsecutivePriority == b.ConsecutivePriority &&
+		boolPtrEqual(a.ConsecutiveAlerts, b.ConsecutiveAlerts) &&
+		intPtrEqual(a.Window, b.Window) &&
+		a.PercentagePriority == b.PercentagePriority &&
+		boolPtrEqual(a.PercentageAlerts, b.PercentageAlerts) &&
+		intPtrEqual(a.ConsecutiveEmpty, b.ConsecutiveEmpty) &&
+		a.ConsecutiveEmptyPriority == b.ConsecutiveEmptyPriority &&
+		boolPtrEqual(a.ConsecutiveEmptyAlerts, b.ConsecutiveEmptyAlerts) &&
+		intPtrEqual(a.EmptyWindow, b.EmptyWindow) &&
+		a.EmptyPercentagePriority == b.EmptyPercentagePriority &&
+		boolPtrEqual(a.EmptyPercentageAlerts, b.EmptyPercentageAlerts) &&
+		boolPtrEqual(a.AlertIfInactive, b.AlertIfInactive) &&
+		boolPtrEqual(a.AlertIfNoServers, b.AlertIfNoServers) &&
+		boolPtrEqual(a.GovernanceAlerts, b.GovernanceAlerts) &&
+		boolPtrEqual(a.StakeChangeAlerts, b.StakeChangeAlerts) &&
+		floatPtrEqual(a.StakeChangeDropThreshold, b.StakeChangeDropThreshold) &&
+		floatPtrEqual(a.StakeChangeIncreaseThreshold, b.StakeChangeIncreaseThreshold) &&
+		boolPtrEqual(a.UnclaimedRewardsAlerts, b.UnclaimedRewardsAlerts) &&
+		floatPtrEqual(a.UnclaimedRewardsThreshold, b.UnclaimedRewardsThreshold) &&
+		pdConfigsEqual(a.Pagerduty, b.Pagerduty) &&
+		discordConfigsEqual(a.Discord, b.Discord) &&
+		teleConfigsEqual(a.Telegram, b.Telegram) &&
+		slackConfigsEqual(a.Slack, b.Slack)
+}
+
+func intPtrEqual(a, b *int) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func boolPtrEqual(a, b *bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func floatPtrEqual(a, b *float64) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func pdConfigsEqual(a, b PDConfig) bool {
+	return boolPtrEqual(a.Enabled, b.Enabled) &&
+		a.ApiKey == b.ApiKey &&
+		a.DefaultSeverity == b.DefaultSeverity &&
+		a.SeverityThreshold == b.SeverityThreshold
+}
+
+func discordConfigsEqual(a, b DiscordConfig) bool {
+	return boolPtrEqual(a.Enabled, b.Enabled) &&
+		a.Webhook == b.Webhook &&
+		stringSlicesEqual(a.Mentions, b.Mentions) &&
+		a.SeverityThreshold == b.SeverityThreshold
+}
+
+func teleConfigsEqual(a, b TeleConfig) bool {
+	return boolPtrEqual(a.Enabled, b.Enabled) &&
+		a.ApiKey == b.ApiKey &&
+		a.Channel == b.Channel &&
+		stringSlicesEqual(a.Mentions, b.Mentions) &&
+		a.SeverityThreshold == b.SeverityThreshold
+}
+
+func slackConfigsEqual(a, b SlackConfig) bool {
+	return boolPtrEqual(a.Enabled, b.Enabled) &&
+		a.Webhook == b.Webhook &&
+		stringSlicesEqual(a.Mentions, b.Mentions) &&
+		a.SeverityThreshold == b.SeverityThreshold
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestApplyAlertDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		dst      AlertConfig
+		src      AlertConfig
+		expected AlertConfig
+	}{
+		{
+			name: "apply all defaults to empty config",
+			dst:  AlertConfig{},
+			src: AlertConfig{
+				Stalled:                          intPtr(10),
+				StalledAlerts:                    boolPtr(true),
+				ConsecutiveMissed:                intPtr(5),
+				ConsecutivePriority:              "high",
+				ConsecutiveAlerts:                boolPtr(true),
+				Window:                           intPtr(20),
+				PercentagePriority:               "medium",
+				PercentageAlerts:                 boolPtr(false),
+				ConsecutiveEmpty:                 intPtr(15),
+				ConsecutiveEmptyPriority:         "low",
+				ConsecutiveEmptyAlerts:           boolPtr(true),
+				EmptyWindow:                      intPtr(30),
+				EmptyPercentagePriority:          "critical",
+				EmptyPercentageAlerts:            boolPtr(false),
+				AlertIfInactive:                  boolPtr(true),
+				AlertIfNoServers:                 boolPtr(true),
+				GovernanceAlerts:                 boolPtr(true),
+				StakeChangeAlerts:                boolPtr(false),
+				StakeChangeDropThreshold:         floatPtr(5.0),
+				StakeChangeIncreaseThreshold:     floatPtr(10.0),
+				UnclaimedRewardsAlerts:           boolPtr(true),
+				UnclaimedRewardsThreshold:        floatPtr(100.0),
+			},
+			expected: AlertConfig{
+				Stalled:                          intPtr(10),
+				StalledAlerts:                    boolPtr(true),
+				ConsecutiveMissed:                intPtr(5),
+				ConsecutivePriority:              "high",
+				ConsecutiveAlerts:                boolPtr(true),
+				Window:                           intPtr(20),
+				PercentagePriority:               "medium",
+				PercentageAlerts:                 boolPtr(false),
+				ConsecutiveEmpty:                 intPtr(15),
+				ConsecutiveEmptyPriority:         "low",
+				ConsecutiveEmptyAlerts:           boolPtr(true),
+				EmptyWindow:                      intPtr(30),
+				EmptyPercentagePriority:          "critical",
+				EmptyPercentageAlerts:            boolPtr(false),
+				AlertIfInactive:                  boolPtr(true),
+				AlertIfNoServers:                 boolPtr(true),
+				GovernanceAlerts:                 boolPtr(true),
+				StakeChangeAlerts:                boolPtr(false),
+				StakeChangeDropThreshold:         floatPtr(5.0),
+				StakeChangeIncreaseThreshold:     floatPtr(10.0),
+				UnclaimedRewardsAlerts:           boolPtr(true),
+				UnclaimedRewardsThreshold:        floatPtr(100.0),
+			},
+		},
+		{
+			name: "preserve existing values, only fill zeros",
+			dst: AlertConfig{
+				Stalled:                          intPtr(25),
+				StalledAlerts:                    boolPtr(false),
+				ConsecutiveMissed:                intPtr(8),
+				ConsecutivePriority:              "critical",
+				Window:                           intPtr(50),
+				PercentagePriority:               "high",
+				StakeChangeDropThreshold:         floatPtr(15.0),
+			},
+			src: AlertConfig{
+				Stalled:                          intPtr(10),
+				StalledAlerts:                    boolPtr(true),
+				ConsecutiveMissed:                intPtr(5),
+				ConsecutivePriority:              "medium",
+				ConsecutiveAlerts:                boolPtr(true),
+				Window:                           intPtr(20),
+				PercentagePriority:               "low",
+				PercentageAlerts:                 boolPtr(false),
+				ConsecutiveEmpty:                 intPtr(15),
+				ConsecutiveEmptyPriority:         "low",
+				ConsecutiveEmptyAlerts:           boolPtr(true),
+				AlertIfInactive:                  boolPtr(true),
+				StakeChangeDropThreshold:         floatPtr(5.0),
+			},
+			expected: AlertConfig{
+				Stalled:                          intPtr(25), // preserved
+				StalledAlerts:                    boolPtr(false), // preserved
+				ConsecutiveMissed:                intPtr(8), // preserved
+				ConsecutivePriority:              "critical", // preserved
+				ConsecutiveAlerts:                boolPtr(true), // filled from src
+				Window:                           intPtr(50), // preserved
+				PercentagePriority:               "high", // preserved
+				PercentageAlerts:                 boolPtr(false), // filled from src
+				ConsecutiveEmpty:                 intPtr(15), // filled from src
+				ConsecutiveEmptyPriority:         "low", // filled from src
+				ConsecutiveEmptyAlerts:           boolPtr(true), // filled from src
+				AlertIfInactive:                  boolPtr(true), // filled from src
+				StakeChangeDropThreshold:         floatPtr(15.0), // preserved
+			},
+		},
+		{
+			name: "nested struct PagerDuty config",
+			dst: AlertConfig{
+				Pagerduty: PDConfig{},
+			},
+			src: AlertConfig{
+				Pagerduty: PDConfig{
+					Enabled:           boolPtr(true),
+					ApiKey:            "test-key",
+					DefaultSeverity:   "critical",
+					SeverityThreshold: "warning",
+				},
+			},
+			expected: AlertConfig{
+				Pagerduty: PDConfig{
+					Enabled:           boolPtr(true),
+					ApiKey:            "test-key",
+					DefaultSeverity:   "critical",
+					SeverityThreshold: "warning",
+				},
+			},
+		},
+		{
+			name: "nested struct partial override",
+			dst: AlertConfig{
+				Pagerduty: PDConfig{
+					Enabled: boolPtr(false),
+					ApiKey:  "existing-key",
+				},
+			},
+			src: AlertConfig{
+				Pagerduty: PDConfig{
+					Enabled:           boolPtr(true),
+					ApiKey:            "default-key",
+					DefaultSeverity:   "warning",
+					SeverityThreshold: "info",
+				},
+			},
+			expected: AlertConfig{
+				Pagerduty: PDConfig{
+					Enabled:           boolPtr(false), // preserved
+					ApiKey:            "existing-key", // preserved
+					DefaultSeverity:   "warning", // filled from src
+					SeverityThreshold: "info", // filled from src
+				},
+			},
+		},
+		{
+			name: "pointer field handling - nil vs non-nil",
+			dst: AlertConfig{
+				Stalled: nil, // nil pointer should be filled
+				StalledAlerts: boolPtr(true), // non-nil should be preserved
+			},
+			src: AlertConfig{
+				Stalled: intPtr(10),
+				StalledAlerts: boolPtr(false),
+			},
+			expected: AlertConfig{
+				Stalled: intPtr(10), // should be filled from src (was nil)
+				StalledAlerts: boolPtr(true), // should be preserved (was non-nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy of dst to avoid modifying the test case
+			dst := tt.dst
+			applyAlertDefaults(&dst, &tt.src)
+			
+			if !alertConfigsEqual(dst, tt.expected) {
+				t.Errorf("applyAlertDefaults() mismatch")
+				t.Logf("Stalled - Got: %v, Expected: %v", ptrIntToString(dst.Stalled), ptrIntToString(tt.expected.Stalled))
+				t.Logf("StalledAlerts - Got: %v, Expected: %v", ptrBoolToString(dst.StalledAlerts), ptrBoolToString(tt.expected.StalledAlerts))
+			}
+		})
+	}
+}
+
+func TestIsZero(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected bool
+	}{
+		{"zero int", 0, true},
+		{"non-zero int", 5, false},
+		{"zero string", "", true},
+		{"non-zero string", "hello", false},
+		{"zero bool", false, true},
+		{"non-zero bool", true, false},
+		{"zero float64", 0.0, true},
+		{"non-zero float64", 3.14, false},
+		{"nil pointer", (*int)(nil), true},
+		{"non-nil pointer", intPtr(42), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := reflect.ValueOf(tt.value)
+			result := isZero(v)
+			if result != tt.expected {
+				t.Errorf("isZero(%v) = %v, expected %v", tt.value, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestApplyAlertDefaultsWithComplexNesting(t *testing.T) {
+	// Test with multiple nested structs
+	dst := AlertConfig{
+		Pagerduty: PDConfig{
+			Enabled: boolPtr(true),
+		},
+		Discord: DiscordConfig{
+			Webhook: "existing-webhook",
+		},
+		Telegram: TeleConfig{},
+	}
+
+	src := AlertConfig{
+		Pagerduty: PDConfig{
+			Enabled:           boolPtr(false),
+			ApiKey:            "default-key",
+			DefaultSeverity:   "warning",
+			SeverityThreshold: "info",
+		},
+		Discord: DiscordConfig{
+			Enabled:           boolPtr(true),
+			Webhook:           "default-webhook",
+			Mentions:          []string{"@here"},
+			SeverityThreshold: "critical",
+		},
+		Telegram: TeleConfig{
+			Enabled:           boolPtr(true),
+			ApiKey:            "telegram-key",
+			Channel:           "alerts",
+			Mentions:          []string{"@admin"},
+			SeverityThreshold: "warning",
+		},
+	}
+
+	expected := AlertConfig{
+		Pagerduty: PDConfig{
+			Enabled:           boolPtr(true), // preserved from dst
+			ApiKey:            "default-key", // filled from src
+			DefaultSeverity:   "warning", // filled from src
+			SeverityThreshold: "info", // filled from src
+		},
+		Discord: DiscordConfig{
+			Enabled:           boolPtr(true), // filled from src
+			Webhook:           "existing-webhook", // preserved from dst
+			Mentions:          []string{"@here"}, // filled from src
+			SeverityThreshold: "critical", // filled from src
+		},
+		Telegram: TeleConfig{
+			Enabled:           boolPtr(true), // filled from src
+			ApiKey:            "telegram-key", // filled from src
+			Channel:           "alerts", // filled from src
+			Mentions:          []string{"@admin"}, // filled from src
+			SeverityThreshold: "warning", // filled from src
+		},
+	}
+
+	applyAlertDefaults(&dst, &src)
+
+	if !alertConfigsEqual(dst, expected) {
+		t.Errorf("Complex nesting test failed\nGot:      %+v\nExpected: %+v", dst, expected)
+	}
+}
+
+func TestApplyAlertDefaultsWithPointerFields(t *testing.T) {
+	// Test pointer field handling specifically
+	dst := AlertConfig{
+		Stalled:          nil, // nil pointer should be filled
+		StalledAlerts:    boolPtr(false), // non-nil pointer should be preserved
+		ConsecutiveMissed: intPtr(0), // non-nil pointer should be preserved even if zero
+	}
+
+	src := AlertConfig{
+		Stalled:          intPtr(30),
+		StalledAlerts:    boolPtr(true),
+		ConsecutiveMissed: intPtr(10),
+	}
+
+	expected := AlertConfig{
+		Stalled:          intPtr(30), // filled from src (was nil)
+		StalledAlerts:    boolPtr(false), // preserved from dst (non-nil)
+		ConsecutiveMissed: intPtr(0), // preserved from dst (non-nil, even though zero)
+	}
+
+	applyAlertDefaults(&dst, &src)
+
+	if !alertConfigsEqual(dst, expected) {
+		t.Errorf("Pointer fields test failed\nGot:      %+v\nExpected: %+v", dst, expected)
+	}
+}
+
+// Helper functions for creating pointers
+func intPtr(i int) *int {
+	return &i
+}
+
+// Debug helper functions
+func ptrIntToString(p *int) string {
+	if p == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("%d", *p)
+}
+
+func ptrBoolToString(p *bool) string {
+	if p == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("%t", *p)
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func floatPtr(f float64) *float64 {
+	return &f
+}
+
+// Test utility functions
+func TestBoolVal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *bool
+		expected bool
+	}{
+		{"nil pointer", nil, false},
+		{"false pointer", boolPtr(false), false},
+		{"true pointer", boolPtr(true), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := boolVal(tt.input)
+			if result != tt.expected {
+				t.Errorf("boolVal(%v) = %v, expected %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIntVal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *int
+		expected int
+	}{
+		{"nil pointer", nil, 0},
+		{"zero pointer", intPtr(0), 0},
+		{"positive pointer", intPtr(42), 42},
+		{"negative pointer", intPtr(-5), -5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := intVal(tt.input)
+			if result != tt.expected {
+				t.Errorf("intVal(%v) = %v, expected %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFloatVal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *float64
+		expected float64
+	}{
+		{"nil pointer", nil, 0.0},
+		{"zero pointer", floatPtr(0.0), 0.0},
+		{"positive pointer", floatPtr(3.14), 3.14},
+		{"negative pointer", floatPtr(-2.5), -2.5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := floatVal(tt.input)
+			if result != tt.expected {
+				t.Errorf("floatVal(%v) = %v, expected %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/td2/types_test.go
+++ b/td2/types_test.go
@@ -118,94 +118,94 @@ func TestApplyAlertDefaults(t *testing.T) {
 			name: "apply all defaults to empty config",
 			dst:  AlertConfig{},
 			src: AlertConfig{
-				Stalled:                          intPtr(10),
-				StalledAlerts:                    boolPtr(true),
-				ConsecutiveMissed:                intPtr(5),
-				ConsecutivePriority:              "high",
-				ConsecutiveAlerts:                boolPtr(true),
-				Window:                           intPtr(20),
-				PercentagePriority:               "medium",
-				PercentageAlerts:                 boolPtr(false),
-				ConsecutiveEmpty:                 intPtr(15),
-				ConsecutiveEmptyPriority:         "low",
-				ConsecutiveEmptyAlerts:           boolPtr(true),
-				EmptyWindow:                      intPtr(30),
-				EmptyPercentagePriority:          "critical",
-				EmptyPercentageAlerts:            boolPtr(false),
-				AlertIfInactive:                  boolPtr(true),
-				AlertIfNoServers:                 boolPtr(true),
-				GovernanceAlerts:                 boolPtr(true),
-				StakeChangeAlerts:                boolPtr(false),
-				StakeChangeDropThreshold:         floatPtr(5.0),
-				StakeChangeIncreaseThreshold:     floatPtr(10.0),
-				UnclaimedRewardsAlerts:           boolPtr(true),
-				UnclaimedRewardsThreshold:        floatPtr(100.0),
+				Stalled:                      intPtr(10),
+				StalledAlerts:                boolPtr(true),
+				ConsecutiveMissed:            intPtr(5),
+				ConsecutivePriority:          "high",
+				ConsecutiveAlerts:            boolPtr(true),
+				Window:                       intPtr(20),
+				PercentagePriority:           "medium",
+				PercentageAlerts:             boolPtr(false),
+				ConsecutiveEmpty:             intPtr(15),
+				ConsecutiveEmptyPriority:     "low",
+				ConsecutiveEmptyAlerts:       boolPtr(true),
+				EmptyWindow:                  intPtr(30),
+				EmptyPercentagePriority:      "critical",
+				EmptyPercentageAlerts:        boolPtr(false),
+				AlertIfInactive:              boolPtr(true),
+				AlertIfNoServers:             boolPtr(true),
+				GovernanceAlerts:             boolPtr(true),
+				StakeChangeAlerts:            boolPtr(false),
+				StakeChangeDropThreshold:     floatPtr(5.0),
+				StakeChangeIncreaseThreshold: floatPtr(10.0),
+				UnclaimedRewardsAlerts:       boolPtr(true),
+				UnclaimedRewardsThreshold:    floatPtr(100.0),
 			},
 			expected: AlertConfig{
-				Stalled:                          intPtr(10),
-				StalledAlerts:                    boolPtr(true),
-				ConsecutiveMissed:                intPtr(5),
-				ConsecutivePriority:              "high",
-				ConsecutiveAlerts:                boolPtr(true),
-				Window:                           intPtr(20),
-				PercentagePriority:               "medium",
-				PercentageAlerts:                 boolPtr(false),
-				ConsecutiveEmpty:                 intPtr(15),
-				ConsecutiveEmptyPriority:         "low",
-				ConsecutiveEmptyAlerts:           boolPtr(true),
-				EmptyWindow:                      intPtr(30),
-				EmptyPercentagePriority:          "critical",
-				EmptyPercentageAlerts:            boolPtr(false),
-				AlertIfInactive:                  boolPtr(true),
-				AlertIfNoServers:                 boolPtr(true),
-				GovernanceAlerts:                 boolPtr(true),
-				StakeChangeAlerts:                boolPtr(false),
-				StakeChangeDropThreshold:         floatPtr(5.0),
-				StakeChangeIncreaseThreshold:     floatPtr(10.0),
-				UnclaimedRewardsAlerts:           boolPtr(true),
-				UnclaimedRewardsThreshold:        floatPtr(100.0),
+				Stalled:                      intPtr(10),
+				StalledAlerts:                boolPtr(true),
+				ConsecutiveMissed:            intPtr(5),
+				ConsecutivePriority:          "high",
+				ConsecutiveAlerts:            boolPtr(true),
+				Window:                       intPtr(20),
+				PercentagePriority:           "medium",
+				PercentageAlerts:             boolPtr(false),
+				ConsecutiveEmpty:             intPtr(15),
+				ConsecutiveEmptyPriority:     "low",
+				ConsecutiveEmptyAlerts:       boolPtr(true),
+				EmptyWindow:                  intPtr(30),
+				EmptyPercentagePriority:      "critical",
+				EmptyPercentageAlerts:        boolPtr(false),
+				AlertIfInactive:              boolPtr(true),
+				AlertIfNoServers:             boolPtr(true),
+				GovernanceAlerts:             boolPtr(true),
+				StakeChangeAlerts:            boolPtr(false),
+				StakeChangeDropThreshold:     floatPtr(5.0),
+				StakeChangeIncreaseThreshold: floatPtr(10.0),
+				UnclaimedRewardsAlerts:       boolPtr(true),
+				UnclaimedRewardsThreshold:    floatPtr(100.0),
 			},
 		},
 		{
 			name: "preserve existing values, only fill zeros",
 			dst: AlertConfig{
-				Stalled:                          intPtr(25),
-				StalledAlerts:                    boolPtr(false),
-				ConsecutiveMissed:                intPtr(8),
-				ConsecutivePriority:              "critical",
-				Window:                           intPtr(50),
-				PercentagePriority:               "high",
-				StakeChangeDropThreshold:         floatPtr(15.0),
+				Stalled:                  intPtr(25),
+				StalledAlerts:            boolPtr(false),
+				ConsecutiveMissed:        intPtr(8),
+				ConsecutivePriority:      "critical",
+				Window:                   intPtr(50),
+				PercentagePriority:       "high",
+				StakeChangeDropThreshold: floatPtr(15.0),
 			},
 			src: AlertConfig{
-				Stalled:                          intPtr(10),
-				StalledAlerts:                    boolPtr(true),
-				ConsecutiveMissed:                intPtr(5),
-				ConsecutivePriority:              "medium",
-				ConsecutiveAlerts:                boolPtr(true),
-				Window:                           intPtr(20),
-				PercentagePriority:               "low",
-				PercentageAlerts:                 boolPtr(false),
-				ConsecutiveEmpty:                 intPtr(15),
-				ConsecutiveEmptyPriority:         "low",
-				ConsecutiveEmptyAlerts:           boolPtr(true),
-				AlertIfInactive:                  boolPtr(true),
-				StakeChangeDropThreshold:         floatPtr(5.0),
+				Stalled:                  intPtr(10),
+				StalledAlerts:            boolPtr(true),
+				ConsecutiveMissed:        intPtr(5),
+				ConsecutivePriority:      "medium",
+				ConsecutiveAlerts:        boolPtr(true),
+				Window:                   intPtr(20),
+				PercentagePriority:       "low",
+				PercentageAlerts:         boolPtr(false),
+				ConsecutiveEmpty:         intPtr(15),
+				ConsecutiveEmptyPriority: "low",
+				ConsecutiveEmptyAlerts:   boolPtr(true),
+				AlertIfInactive:          boolPtr(true),
+				StakeChangeDropThreshold: floatPtr(5.0),
 			},
 			expected: AlertConfig{
-				Stalled:                          intPtr(25), // preserved
-				StalledAlerts:                    boolPtr(false), // preserved
-				ConsecutiveMissed:                intPtr(8), // preserved
-				ConsecutivePriority:              "critical", // preserved
-				ConsecutiveAlerts:                boolPtr(true), // filled from src
-				Window:                           intPtr(50), // preserved
-				PercentagePriority:               "high", // preserved
-				PercentageAlerts:                 boolPtr(false), // filled from src
-				ConsecutiveEmpty:                 intPtr(15), // filled from src
-				ConsecutiveEmptyPriority:         "low", // filled from src
-				ConsecutiveEmptyAlerts:           boolPtr(true), // filled from src
-				AlertIfInactive:                  boolPtr(true), // filled from src
-				StakeChangeDropThreshold:         floatPtr(15.0), // preserved
+				Stalled:                  intPtr(25),     // preserved
+				StalledAlerts:            boolPtr(false), // preserved
+				ConsecutiveMissed:        intPtr(8),      // preserved
+				ConsecutivePriority:      "critical",     // preserved
+				ConsecutiveAlerts:        boolPtr(true),  // filled from src
+				Window:                   intPtr(50),     // preserved
+				PercentagePriority:       "high",         // preserved
+				PercentageAlerts:         boolPtr(false), // filled from src
+				ConsecutiveEmpty:         intPtr(15),     // filled from src
+				ConsecutiveEmptyPriority: "low",          // filled from src
+				ConsecutiveEmptyAlerts:   boolPtr(true),  // filled from src
+				AlertIfInactive:          boolPtr(true),  // filled from src
+				StakeChangeDropThreshold: floatPtr(15.0), // preserved
 			},
 		},
 		{
@@ -250,23 +250,23 @@ func TestApplyAlertDefaults(t *testing.T) {
 				Pagerduty: PDConfig{
 					Enabled:           boolPtr(false), // preserved
 					ApiKey:            "existing-key", // preserved
-					DefaultSeverity:   "warning", // filled from src
-					SeverityThreshold: "info", // filled from src
+					DefaultSeverity:   "warning",      // filled from src
+					SeverityThreshold: "info",         // filled from src
 				},
 			},
 		},
 		{
 			name: "pointer field handling - nil vs non-nil",
 			dst: AlertConfig{
-				Stalled: nil, // nil pointer should be filled
+				Stalled:       nil,           // nil pointer should be filled
 				StalledAlerts: boolPtr(true), // non-nil should be preserved
 			},
 			src: AlertConfig{
-				Stalled: intPtr(10),
+				Stalled:       intPtr(10),
 				StalledAlerts: boolPtr(false),
 			},
 			expected: AlertConfig{
-				Stalled: intPtr(10), // should be filled from src (was nil)
+				Stalled:       intPtr(10),    // should be filled from src (was nil)
 				StalledAlerts: boolPtr(true), // should be preserved (was non-nil)
 			},
 		},
@@ -277,7 +277,7 @@ func TestApplyAlertDefaults(t *testing.T) {
 			// Make a copy of dst to avoid modifying the test case
 			dst := tt.dst
 			applyAlertDefaults(&dst, &tt.src)
-			
+
 			if !alertConfigsEqual(dst, tt.expected) {
 				t.Errorf("applyAlertDefaults() mismatch")
 				t.Logf("Stalled - Got: %v, Expected: %v", ptrIntToString(dst.Stalled), ptrIntToString(tt.expected.Stalled))
@@ -290,7 +290,7 @@ func TestApplyAlertDefaults(t *testing.T) {
 func TestIsZero(t *testing.T) {
 	tests := []struct {
 		name     string
-		value    interface{}
+		value    any
 		expected bool
 	}{
 		{"zero int", 0, true},
@@ -354,21 +354,21 @@ func TestApplyAlertDefaultsWithComplexNesting(t *testing.T) {
 		Pagerduty: PDConfig{
 			Enabled:           boolPtr(true), // preserved from dst
 			ApiKey:            "default-key", // filled from src
-			DefaultSeverity:   "warning", // filled from src
-			SeverityThreshold: "info", // filled from src
+			DefaultSeverity:   "warning",     // filled from src
+			SeverityThreshold: "info",        // filled from src
 		},
 		Discord: DiscordConfig{
-			Enabled:           boolPtr(true), // filled from src
+			Enabled:           boolPtr(true),      // filled from src
 			Webhook:           "existing-webhook", // preserved from dst
-			Mentions:          []string{"@here"}, // filled from src
-			SeverityThreshold: "critical", // filled from src
+			Mentions:          []string{"@here"},  // filled from src
+			SeverityThreshold: "critical",         // filled from src
 		},
 		Telegram: TeleConfig{
-			Enabled:           boolPtr(true), // filled from src
-			ApiKey:            "telegram-key", // filled from src
-			Channel:           "alerts", // filled from src
+			Enabled:           boolPtr(true),      // filled from src
+			ApiKey:            "telegram-key",     // filled from src
+			Channel:           "alerts",           // filled from src
 			Mentions:          []string{"@admin"}, // filled from src
-			SeverityThreshold: "warning", // filled from src
+			SeverityThreshold: "warning",          // filled from src
 		},
 	}
 
@@ -382,21 +382,21 @@ func TestApplyAlertDefaultsWithComplexNesting(t *testing.T) {
 func TestApplyAlertDefaultsWithPointerFields(t *testing.T) {
 	// Test pointer field handling specifically
 	dst := AlertConfig{
-		Stalled:          nil, // nil pointer should be filled
-		StalledAlerts:    boolPtr(false), // non-nil pointer should be preserved
-		ConsecutiveMissed: intPtr(0), // non-nil pointer should be preserved even if zero
+		Stalled:           nil,            // nil pointer should be filled
+		StalledAlerts:     boolPtr(false), // non-nil pointer should be preserved
+		ConsecutiveMissed: intPtr(0),      // non-nil pointer should be preserved even if zero
 	}
 
 	src := AlertConfig{
-		Stalled:          intPtr(30),
-		StalledAlerts:    boolPtr(true),
+		Stalled:           intPtr(30),
+		StalledAlerts:     boolPtr(true),
 		ConsecutiveMissed: intPtr(10),
 	}
 
 	expected := AlertConfig{
-		Stalled:          intPtr(30), // filled from src (was nil)
-		StalledAlerts:    boolPtr(false), // preserved from dst (non-nil)
-		ConsecutiveMissed: intPtr(0), // preserved from dst (non-nil, even though zero)
+		Stalled:           intPtr(30),     // filled from src (was nil)
+		StalledAlerts:     boolPtr(false), // preserved from dst (non-nil)
+		ConsecutiveMissed: intPtr(0),      // preserved from dst (non-nil, even though zero)
 	}
 
 	applyAlertDefaults(&dst, &src)
@@ -499,3 +499,4 @@ func TestFloatVal(t *testing.T) {
 		})
 	}
 }
+

--- a/td2/validator.go
+++ b/td2/validator.go
@@ -267,7 +267,7 @@ func (cc *ChainConfig) GetValInfo(first bool) (err error) {
 	}
 
 	// Log if governance alerts are disabled (only on first run)
-	if first && !cc.Alerts.GovernanceAlerts {
+	if first && !boolVal(cc.Alerts.GovernanceAlerts) {
 		l(fmt.Sprintf("ℹ️ Governance alerts disabled for %s (%s)", cc.ValAddress, cc.valInfo.Moniker))
 	}
 


### PR DESCRIPTION
## Summary
- add helper to copy default AlertConfig values
- apply defaults when validating chain configs
- expand `default_alert_config` in example config