### PR TITLE
#24 calculate each validator's projected 30-day rewards

### DIFF
--- a/td2/dashboard/types.go
+++ b/td2/dashboard/types.go
@@ -2,6 +2,7 @@ package dash
 
 import (
 	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
+	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
 	utils "github.com/firstset/tenderduty/v2/td2/utils"
 )
 
@@ -34,6 +35,8 @@ type ChainStatus struct {
 	SelfDelegationRewards   *github_com_cosmos_cosmos_sdk_types.DecCoins `json:"self_delegation_rewards"`
 	Commission              *github_com_cosmos_cosmos_sdk_types.DecCoins `json:"commission"`
 	CryptoPrice             *utils.CryptoPrice                           `json:"crypto_price"`
+	DenomMetadata           *bank.Metadata                               `json:"demom_metadata"`
+	Projected30DRewards     float64                                      `json:"projected_30d_rewards"`
 
 	Blocks []int `json:"blocks"`
 }

--- a/td2/rpc.go
+++ b/td2/rpc.go
@@ -137,6 +137,8 @@ func (cc *ChainConfig) newRpc() error {
 			SelfDelegationRewards:   cc.valInfo.SelfDelegationRewards,
 			Commission:              cc.valInfo.Commission,
 			CryptoPrice:             cc.cryptoPrice,
+			DenomMetadata:           cc.denomMetadata,
+			Projected30DRewards:     cc.valInfo.Projected30DRewards,
 		}
 	}
 	return errors.New("no usable endpoints available for " + cc.ChainId)

--- a/td2/static/index.html
+++ b/td2/static/index.html
@@ -111,7 +111,7 @@
                 <th>Height</th>
                 <th>Moniker</th>
                 <th class="uk-text-center">Voting Power</th>
-                <th class="uk-text-center">APR</th>
+                <th class="uk-text-center">30D Rewards</th>
                 <th class="uk-text-center">Unvoted Prop.</th>
                 <th class="uk-text-center">Uptime</th>
                 <th class="uk-text-center">Threshold</th>

--- a/td2/static/js/table-renderer.js
+++ b/td2/static/js/table-renderer.js
@@ -210,9 +210,9 @@ export class TableRenderer {
         `<div class="uk-text-center"><span class="uk-width-1-2">${(100 * chainStatus.voting_power_percent).toFixed(1)}%</span></div>`;
       columnIndex++;
 
-      // Column: Validator APR
+      // Column: Validator Projected 30-day Rewards
       row.insertCell(columnIndex).innerHTML =
-        `<div class="uk-text-center"><span class="uk-width-1-2">${(100 * chainStatus.validator_apr).toFixed(1)}%</span></div>`;
+        `<div class="uk-text-center"><span class="uk-width-1-2">${chainStatus.projected_30d_rewards.toFixed(1)}</span></div>`;
       columnIndex++;
 
       // Column: Unvoted Proposals
@@ -240,4 +240,3 @@ export class TableRenderer {
     }
   }
 }
-

--- a/td2/types.go
+++ b/td2/types.go
@@ -443,6 +443,8 @@ func validateConfig(c *Config) (fatal bool, problems []string) {
 				SelfDelegationRewards:   v.valInfo.SelfDelegationRewards,
 				Commission:              v.valInfo.Commission,
 				CryptoPrice:             v.cryptoPrice,
+				DenomMetadata:           v.denomMetadata,
+				Projected30DRewards:     v.valInfo.Projected30DRewards,
 			}
 		}
 	}

--- a/td2/validator.go
+++ b/td2/validator.go
@@ -30,6 +30,7 @@ type ValInfo struct {
 	VotingPowerPercent    float64                                      `json:"voting_power_percent"`
 	CommissionRate        float64                                      `json:"commission_rate"`
 	ValidatorAPR          float64                                      `json:"validator_apr"`
+	Projected30DRewards   float64                                      `json:"projected_30d_rewards"`
 	SelfDelegationRewards *github_com_cosmos_cosmos_sdk_types.DecCoins `json:"self_delegation_rewards"`
 	Commission            *github_com_cosmos_cosmos_sdk_types.DecCoins `json:"commission"`
 }
@@ -250,6 +251,33 @@ func (cc *ChainConfig) GetValInfo(first bool) (err error) {
 			cc.inflationRate = inflationRate
 			cc.baseAPR = inflationRate * (1 - communityTax) * totalSupply / cc.totalBondedTokens
 			cc.valInfo.ValidatorAPR = cc.baseAPR * (1 - cc.valInfo.CommissionRate)
+
+			if cc.cryptoPrice != nil {
+				// Calculate the validator's projected 30-day rewards in base units
+				projected30DRewardsBaseUnits := cc.valInfo.DelegatedTokens * cc.valInfo.ValidatorAPR * cc.valInfo.CommissionRate * 30 / 365
+
+				// Convert from base units to display units using exponent
+				var displayExponent uint32 = 0
+				if cc.denomMetadata.Display != "" {
+					// Find the exponent for the display denomination
+					for _, unit := range cc.denomMetadata.DenomUnits {
+						if unit.Denom == cc.denomMetadata.Display {
+							displayExponent = unit.Exponent
+							break
+						}
+					}
+				}
+
+				// Convert to display units by dividing by 10^exponent
+				projected30DRewardsDisplayUnits := projected30DRewardsBaseUnits
+				for i := uint32(0); i < displayExponent; i++ {
+					projected30DRewardsDisplayUnits = projected30DRewardsDisplayUnits / 10
+				}
+
+				// Convert to fiat currency
+				cc.valInfo.Projected30DRewards = projected30DRewardsDisplayUnits * cc.cryptoPrice.Price
+			}
+
 		} else {
 			l(fmt.Errorf("failed to query APR-related data such as total supply, community tax and inflation rate for chain %s, err: %w", cc.name, err))
 		}

--- a/td2/ws.go
+++ b/td2/ws.go
@@ -208,6 +208,8 @@ func (cc *ChainConfig) WsRun() {
 							SelfDelegationRewards:   cc.valInfo.SelfDelegationRewards,
 							Commission:              cc.valInfo.Commission,
 							CryptoPrice:             cc.cryptoPrice,
+							DenomMetadata:           cc.denomMetadata,
+							Projected30DRewards:     cc.valInfo.Projected30DRewards,
 						}
 					}
 


### PR DESCRIPTION
Instead of showing APR in the dashboard, we display each validator's projected 30-day rewards in the configured fiat currency now 🚀 