### PR TITLE
fix Tenderduty sometimes uses incorrect denom metadata

### DIFF
--- a/td2/chain-details.go
+++ b/td2/chain-details.go
@@ -177,6 +177,7 @@ type CosmosDirectoryChainData struct {
 	Path      string    `json:"path"`
 	ChainName string    `json:"chain_name"`
 	Symbol    string    `json:"symbol"`
+	Display   string    `json:"display"`
 	Decimals  int       `json:"decimals"`
 	Denom     string    `json:"denom"`
 	Params    CDParams  `json:"params"`
@@ -387,7 +388,35 @@ func (cc *ChainConfig) getChainInfoFromCosmosDirectory() (communityTax float64, 
 func (cc *ChainConfig) getBankMetadataFromCosmosDirectory(denom string) *bank.Metadata {
 	cdAsset := cc.getDenomMetadataFromCosmosDirectory(denom)
 	if cdAsset == nil {
-		return nil
+		if cc.cosmosDirectoryData == nil || cc.cosmosDirectoryData.Denom == "" {
+			return nil
+		}
+		display := cc.cosmosDirectoryData.Display
+		if display == "" {
+			display = cc.cosmosDirectoryData.Symbol
+		}
+
+		denomUnits := []*bank.DenomUnit{
+			{
+				Denom:    cc.cosmosDirectoryData.Denom,
+				Exponent: 0,
+			},
+		}
+		if display != "" && display != cc.cosmosDirectoryData.Denom {
+			denomUnits = append(denomUnits, &bank.DenomUnit{
+				Denom:    display,
+				Exponent: uint32(cc.cosmosDirectoryData.Decimals),
+			})
+		}
+
+		return &bank.Metadata{
+			Description: "",
+			DenomUnits:  denomUnits,
+			Base:        cc.cosmosDirectoryData.Denom,
+			Display:     display,
+			Name:        cc.cosmosDirectoryData.ChainName,
+			Symbol:      cc.cosmosDirectoryData.Symbol,
+		}
 	}
 
 	// Convert CDDenomUnit to bank.DenomUnit

--- a/td2/chain-details.go
+++ b/td2/chain-details.go
@@ -178,7 +178,7 @@ type CosmosDirectoryChainData struct {
 	ChainName string    `json:"chain_name"`
 	Symbol    string    `json:"symbol"`
 	Display   string    `json:"display"`
-	Decimals  int       `json:"decimals"`
+	Decimals  uint32    `json:"decimals"`
 	Denom     string    `json:"denom"`
 	Params    CDParams  `json:"params"`
 	Assets    []CDAsset `json:"assets"`
@@ -405,7 +405,7 @@ func (cc *ChainConfig) getBankMetadataFromCosmosDirectory(denom string) *bank.Me
 		if display != "" && display != cc.cosmosDirectoryData.Denom {
 			denomUnits = append(denomUnits, &bank.DenomUnit{
 				Denom:    display,
-				Exponent: uint32(cc.cosmosDirectoryData.Decimals),
+				Exponent: cc.cosmosDirectoryData.Decimals,
 			})
 		}
 

--- a/td2/provider-default.go
+++ b/td2/provider-default.go
@@ -362,6 +362,27 @@ func (d *DefaultProvider) QuerySlashingParams(ctx context.Context) (*slashing.Pa
 	return &params.Params, nil
 }
 
+func (d *DefaultProvider) QueryStakingParams(ctx context.Context) (*staking.Params, error) {
+	qParams := &staking.QueryParamsRequest{}
+	b, err := qParams.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshal staking params: %w", err)
+	}
+	resp, err := d.ChainConfig.client.ABCIQuery(ctx, "/cosmos.staking.v1beta1.Query/Params", b)
+	if err != nil {
+		return nil, fmt.Errorf("query staking params: %w", err)
+	}
+	if resp.Response.Value == nil {
+		return nil, errors.New("🛑 could not query staking params, got empty response")
+	}
+	params := &staking.QueryParamsResponse{}
+	err = params.Unmarshal(resp.Response.Value)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal staking params: %w", err)
+	}
+	return &params.Params, nil
+}
+
 func (d *DefaultProvider) QueryChainInfo(ctx context.Context) (totalSupply float64, communityTax float64, inflationRate float64, err error) {
 	// Query total supply using bank module
 	supplyQueryParams := bank.QuerySupplyOfRequest{

--- a/td2/provider-namada.go
+++ b/td2/provider-namada.go
@@ -295,6 +295,10 @@ func (d *NamadaProvider) QuerySlashingParams(ctx context.Context) (*slashing.Par
 	return &slashing.Params{SignedBlocksWindow: int64(livenessInfo.LivenessWindowLen), MinSignedPerWindow: cosmos_sdk_types.MustNewDecFromStr(livenessInfo.LivenessThreshold.String())}, nil
 }
 
+func (d *NamadaProvider) QueryStakingParams(ctx context.Context) (*staking.Params, error) {
+	return nil, errors.New("QueryStakingParams with ABCIQuery not implemented for Namada")
+}
+
 func (d *NamadaProvider) QueryDenomMetadata(ctx context.Context, denom string) (medatada *bank.Metadata, err error) {
 	return nil, errors.New("QueryDenomMetadata with ABCIQuery not implemented for Namada")
 }

--- a/td2/types.go
+++ b/td2/types.go
@@ -754,6 +754,7 @@ type ChainProvider interface {
 	QueryValidatorInfo(ctx context.Context) (pub []byte, moniker string, jailed bool, bonded bool, delegatedTokens float64, commissionRate float64, err error)
 	QuerySigningInfo(ctx context.Context) (*slashing.ValidatorSigningInfo, error)
 	QuerySlashingParams(ctx context.Context) (*slashing.Params, error)
+	QueryStakingParams(ctx context.Context) (*staking.Params, error)
 	QueryValidatorVotingPool(ctx context.Context) (votingPool *staking.Pool, err error)
 	QueryValidatorSelfDelegationRewardsAndCommission(ctx context.Context) (rewards *github_com_cosmos_cosmos_sdk_types.DecCoins, commission *github_com_cosmos_cosmos_sdk_types.DecCoins, err error)
 	QueryDenomMetadata(ctx context.Context, denom string) (medatada *bank.Metadata, err error)

--- a/td2/utils/price-conversion.go
+++ b/td2/utils/price-conversion.go
@@ -239,6 +239,9 @@ func ConvertDecCoinToDisplayUnit(coins []github_com_cosmos_cosmos_sdk_types.DecC
 	} else {
 		displayDenom = metadata.Display
 	}
+	if err := github_com_cosmos_cosmos_sdk_types.ValidateDenom(displayDenom); err != nil {
+		return nil, fmt.Errorf("invalid display denom %q for base %q: %w", displayDenom, metadata.Base, err)
+	}
 
 	// Find the exponent for the display denom
 	foundDisplayDenom := false
@@ -325,10 +328,16 @@ func ConvertFloatInBaseUnitToDisplayUnit(value float64, metadata bank.Metadata) 
 	// If no display is set, default to base
 	if metadata.Display == "" {
 		displayDenom = metadata.Base
+		if err := github_com_cosmos_cosmos_sdk_types.ValidateDenom(displayDenom); err != nil {
+			return 0, "", fmt.Errorf("invalid display denom %q for base %q: %w", displayDenom, metadata.Base, err)
+		}
 		// If display is base, no conversion needed
 		return value, displayDenom, nil
 	} else {
 		displayDenom = metadata.Display
+	}
+	if err := github_com_cosmos_cosmos_sdk_types.ValidateDenom(displayDenom); err != nil {
+		return 0, "", fmt.Errorf("invalid display denom %q for base %q: %w", displayDenom, metadata.Base, err)
 	}
 
 	// Find the exponent for the display denom


### PR DESCRIPTION
The root cause is: for some chains there can be different kinds of tokens as self-delegation rewards and commissions. The previous approach gets bank metadata based on the first element in the rewards list, which may not be the native token.

```go
bankMeta = cc.getBankMetadataFromCosmosDirectory((*rewards)[0].Denom)
```